### PR TITLE
Copy the base_folder parameter with strdup

### DIFF
--- a/src/document.c
+++ b/src/document.c
@@ -3295,7 +3295,7 @@ hoedown_document_new(
 	const hoedown_renderer *renderer,
 	hoedown_extensions extensions,
     ext_definition * user_ext,
-    char * base_folder,
+    const char * base_folder,
 	size_t max_nesting)
 {
 	hoedown_document *doc = NULL;
@@ -3306,7 +3306,7 @@ hoedown_document_new(
 	memcpy(&doc->md, renderer, sizeof(hoedown_renderer));
 
 	doc->extensions = user_ext;
-	doc->base_folder = base_folder;
+	doc->base_folder = (base_folder != NULL) ? strdup (base_folder) : NULL;
 
 	doc->counter = (h_counter){0, 0, 0};
 

--- a/src/document.h
+++ b/src/document.h
@@ -244,7 +244,7 @@ hoedown_document *hoedown_document_new(
 	const hoedown_renderer *renderer,
 	hoedown_extensions extensions,
 	ext_definition * exeternal_extensions,
-    char * base_folder,
+    const char * base_folder,
 	size_t max_nesting
 ) __attribute__ ((malloc));
 


### PR DESCRIPTION
This solves #3.

I did not run into any errors when testing this out, but you may want to test it also.